### PR TITLE
Fix some quirks in the hover logic

### DIFF
--- a/static/game.js
+++ b/static/game.js
@@ -42,7 +42,7 @@ function clamp(x, min, max) {
  */
 function getBoardCoordinates(offsetX, offsetY) {
     // HACK: look this up in the stylesheet instead
-    const pieceSize = firstPiece.clientHeight
+    const pieceSize = boxEl.clientHeight / 8
     const boardX = clamp(Math.floor(offsetX / pieceSize), 0, 7)
     const boardY = clamp(Math.floor(offsetY / pieceSize), 0, 7)
     return [boardX, boardY]

--- a/static/game.js
+++ b/static/game.js
@@ -80,21 +80,7 @@ boxEl.addEventListener("mousemove", e => {
 
     // Move the highlight square to that position!
     movePiece(hoverSquareEl, gameX, gameY)
-
-    // Show the highlight square in case it's hidden (i.e. user just tabbed back 
-    // into the window)
-    showHoverSquare()
 })
-
-boxEl.addEventListener("mouseenter", showHoverSquare)
-
-boxEl.addEventListener("mouseleave", e => {
-    hoverSquareEl.hidden = true;
-})
-
-function showHoverSquare() {
-    hoverSquareEl.hidden = false;
-}
 
 boxEl.addEventListener("click", (e => {
     // If it's not a left click, early exit

--- a/static/index.html
+++ b/static/index.html
@@ -20,6 +20,7 @@
         }
 
         #box {
+            box-sizing: border-box;
             position: relative;
             outline: 1px solid black;
             grid-area: box;
@@ -31,17 +32,36 @@
             max-width: 12.5%;
             top: 0;
             left: 0;
+            --piece-offset-x: 0;
+            --piece-offset-y: 0;
+            --px-offset-x: calc(var(--piece-offset-x) * 1px);
+            --px-offset-y: calc(var(--piece-offset-y) * 1px);
+            transform: translate(var(--px-offset-x), var(--px-offset-y));
         }
         
         .piece {
-            transition: 0.25s ease-in-out;
+            transition: transform 0.25s ease-in-out;
         }
 
+        svg {
+            /* For some reason, SVG elements stop event bubbling.
+             * This rule makes SVG elements invisible to mouse events! Yay.
+             */
+            pointer-events: none;
+        }
 
     </style>
 </head>
 <body>
     <div id="box">
+        <!-- Template that we can copy even if there isn't a piece on the board. -->
+        <template id="template_piece">
+            <div class="piece piecesize">
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="50" cy="50" r="25"/>
+                  </svg>
+            </div>
+        </template>
         <div class="piece piecesize">
             <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                 <circle cx="50" cy="50" r="25"/>

--- a/static/index.html
+++ b/static/index.html
@@ -21,8 +21,6 @@
 
         #hoversquare {
             background-color: rgba(250,120,0,0);
-            min-height: 12.5%;
-            min-width: 12.5%;
         }
         
         #hoversquare:hover {
@@ -40,17 +38,19 @@
             position: absolute;
             max-height: 12.5%;
             max-width: 12.5%;
-            top: 0;
-            left: 0;
+            min-height: 12.5%;
+            min-width: 12.5%;
+            top: var(--percent-offset-y);
+            left: var(--percent-offset-x);
             --piece-offset-x: 0;
             --piece-offset-y: 0;
-            --px-offset-x: calc(var(--piece-offset-x) * 1px);
-            --px-offset-y: calc(var(--piece-offset-y) * 1px);
-            transform: translate(var(--px-offset-x), var(--px-offset-y));
+            --percent-offset-x: calc(var(--piece-offset-x) * 1%);
+            --percent-offset-y: calc(var(--piece-offset-y) * 1%);
+            /* transform: translate(var(--px-offset-x), var(--px-offset-y)); */
         }
         
         .piece {
-            transition: transform 0.25s ease-in-out;
+            transition: top, left 0.25s, 0.25s ease-in-out;
         }
 
         svg {
@@ -58,6 +58,7 @@
              * This rule makes SVG elements invisible to mouse events! Yay.
              */
             pointer-events: none;
+            display: block;
         }
 
     </style>

--- a/static/index.html
+++ b/static/index.html
@@ -32,7 +32,7 @@
         #box {
             box-sizing: border-box;
             position: relative;
-            outline: 1px solid black;
+            border: 1px solid black;
             grid-area: box;
         }
 

--- a/static/index.html
+++ b/static/index.html
@@ -19,6 +19,16 @@
                                  ". .   .";
         }
 
+        #hoversquare {
+            background-color: rgba(250,120,0,0);
+            min-height: 12.5%;
+            min-width: 12.5%;
+        }
+        
+        #hoversquare:hover {
+            background-color: rgba(250,120,0,0.44);
+        }
+
         #box {
             box-sizing: border-box;
             position: relative;
@@ -67,10 +77,7 @@
                 <circle cx="50" cy="50" r="25"/>
               </svg>
         </div>       
-        <div id="hoversquare", class="piecesize" hidden>
-            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-                <rect style="fill:rgba(250,120,0,0.44)" width="100" height="100"/>
-              </svg> 
+        <div id="hoversquare" class="piecesize">
         </div>
     </div>
     <script src="game.js"></script>


### PR DESCRIPTION
## What This PR Does:
- Removes the old `animate()` function (it was just for demo purposes anyway)
- Tweaks the `getBoardCoordinates(…)` function:
	-  All output values are now clamped to be in the range [0,7]
	- `pieceSize` is calulated from the size of the `#box` element, not from a random piece element's size.
- Tweaks the `#hoversquare` element:
	- Removes a bunch of JS code responsible for hiding/showing it – now it's CSS-only, yay.
	- Now no longer contains an SVG rectangle, it's just an empty `div`.
	- Also, just a note, but I ought to come up with a less silly name than `hoversquare`. It's wormed into my brain at this point.
- Makes the `#box`'s outline sit flush with the pieces and hoversquare by using the `border` property instead of `outline` (which we can do thanks to the `getBoardCoordinates(…)` tweak!).

### Side Note About Commits
I really recommend keeping each commit you make confined to one new tweak or bit of code – I tried to stick to that ideal in this PR. In VS Code and most other IDEs, you can actually stage specific chunks of code at a time, instead of working file-by-file. I sometimes do two things at once, but stage the two parts in two separate commits. (Of course, you should strive for each commit *working*, which is hard to do if you're plucking bits of the code this way and that… but that's a secondary goal to the commits being readable/revieweable, IMO.) 

Keeping each commit somewhat self-contained makes pull requests a bit easier to review, and makes it easier to track down when a particular change happened.

Anyway, it's nice to do but doesn't matter much. Commit any way you please, don't make your job too hard.